### PR TITLE
Fix Raw mode after the refactoring

### DIFF
--- a/staresc.py
+++ b/staresc.py
@@ -74,7 +74,7 @@ def main() -> int:
             exec=args.exec,
             show=args.show,
             no_tmp=args.no_tmp,
-            no_tty=args.notty,
+            no_tty=args.no_tty,
             no_sftp=args.no_sftp,
             timeout=args.timeout,
         ).run(targets)

--- a/staresc/cli.py
+++ b/staresc/cli.py
@@ -37,9 +37,9 @@ def parse() -> argparse.Namespace:
     rawmode.add_argument('--push',    metavar='filename', action='append', default=[], help='push files to the target')
     rawmode.add_argument('--pull',    metavar='filename', action='append', default=[], help='pull files from the target')
     rawmode.add_argument('--exec',    metavar='filename', action='store',  default='', help='equivalent to "--push file --command ./file"')
-    rawmode.add_argument('--no-tmp',  default=False, action='store_true', help='skip creating temp folder and cd-ing into it')
     rawmode.add_argument('--show',    default=False, action='store_true', help='show commands output in the terminal')
-    rawmode.add_argument('--notty',   default=False, action='store_true', help='SSH only: don\'t request a TTY')
+    rawmode.add_argument('--no-tmp',  default=False, action='store_true', help='skip creating temp folder and cd-ing into it')
+    rawmode.add_argument('--no-tty',   default=False, action='store_true', help='SSH only: don\'t request a TTY')
     rawmode.add_argument('--no-sftp', default=False, action='store_true', help='disable the SFTP subsystem; implies --no-tmp')
 
     checkmode = mode_subparser.add_parser(name='check', help='Check mode: check reachability')

--- a/staresc/cli.py
+++ b/staresc/cli.py
@@ -19,7 +19,7 @@ def parse() -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog='staresc', description=description, epilog=' ', formatter_class=argparse.RawTextHelpFormatter )    
     parser.add_argument('-d',  '--debug',    action='store_true', default=False, help='increase output verbosity to debug mode')
     parser.add_argument('-nb', '--nobanner', action='store_true', default=False, help='hide banner')
-    parser.add_argument('-t', '--timeout', action='store', default=float(2), help='set timeout for connections')
+    parser.add_argument('-t', '--timeout', action='store', default=None, help='set timeout for connections')
 
     maingroup = parser.add_mutually_exclusive_group(required=True)
     maingroup.add_argument('-f',  '--file',       metavar='F', action='store', default='', help='input file containing 1 connection string per line' )
@@ -48,8 +48,16 @@ def parse() -> argparse.Namespace:
     outputs = parser.add_argument_group()
     outputs.add_argument('-o',  '--output', metavar='pattern', action='store', default='', help='export results in specified format')
     outputs.add_argument('-of', '--output-format', metavar='FMT', action='append', default=[], help='format of results')    
-    return parser.parse_args()
-
+    args = parser.parse_args()
+    
+    # Default timeout values
+    if args.timeout:
+        args.timeout = float(args.timeout)
+    elif args.mode == 'raw':
+        args.timeout = float(0)
+    else:
+        args.timeout = float(2)
+    return args
 
 def get_targets(fname:str, single_target:str ) -> list[str]:
     """get_targets parses file or arg to get a list of targets

--- a/staresc/connection/sshconnection.py
+++ b/staresc/connection/sshconnection.py
@@ -54,6 +54,9 @@ class SSHConnection(Connection):
             StarescConnectionError -- raised when the program can't connect to the target 
         """
 
+        if timeout == 0:
+            timeout = None
+
         paramiko_args = {
             'hostname'      : self.hostname,
             'port'          : self.port,
@@ -94,6 +97,10 @@ class SSHConnection(Connection):
             StarescConnectionError -- Failure in connection establishment
             StarescCommandError -- The provided command timed out
         """
+
+        if timeout == 0:
+            timeout = None
+
         try:
             transport = self.client.get_transport()
             if transport:

--- a/staresc/core/raw.py
+++ b/staresc/core/raw.py
@@ -7,7 +7,7 @@ from threading import Event
 from staresc.log import Logger
 from staresc.exporter import Exporter
 from staresc.core.worker import RawWorker
-from staresc.exceptions import RawModeFileTransferError, CommandError
+from staresc.exceptions import RawModeFileTransferError
 
 
 class Raw:
@@ -23,11 +23,11 @@ class Raw:
     stop_event:Event
     timeout:float
 
-    def __init__(self, timeout:float = 2.0, commands:list[str] = [], push:list[str] = [], pull:list[str] = [], exec:str = '', show:bool = False, no_tty:bool = False, no_tmp:bool = False, no_sftp:bool = False) -> None:
+    def __init__(self, timeout = float(0), commands:list[str] = None, push:list[str] = None, pull:list[str] = None, exec:str = '', show:bool = False, no_tty:bool = False, no_tmp:bool = False, no_sftp:bool = False) -> None:
         self.logger     = Logger()
-        self.commands   = commands
-        self.push       = push
-        self.pull       = pull
+        self.commands   = commands or []
+        self.push       = push or []
+        self.pull       = pull or []
         self.show       = show
         self.get_tty    = not no_tty
         self.no_sftp    = no_sftp
@@ -37,14 +37,13 @@ class Raw:
 
         self.workers: list[RawWorker] = []
 
-        if exec != '':
+        if exec and exec != '':
             self.push.append(exec)
             self.commands.append('./' + os.path.basename(exec))
 
         # If the you want to just push/pull files, disable the temp dir creation
-        self.make_temp = len(self.commands) == 0 and not self.no_tmp
+        self.make_temp = len(self.commands) != 0 and not self.no_tmp
         
-    
     def __is_stop_event_set(self) -> bool:
         if self.stop_event.isSet():
             self.logger.debug("event was set")
@@ -59,7 +58,8 @@ class Raw:
                 connection_string=connection_string, 
                 make_temp=self.make_temp, 
                 no_sftp=self.no_sftp, 
-                get_tty=self.get_tty
+                get_tty=self.get_tty,
+                timeout=self.timeout
                 )
             self.logger.raw(
                 target=worker.connection.hostname,
@@ -68,8 +68,8 @@ class Raw:
             )
 
             if self.__is_stop_event_set(): return
-            worker.prepare(timeout=self.timeout)
-            self.workers.append(worker)
+            worker.prepare()
+            self.workers.append(worker) # Appending elements to lists is thread-safe
 
             try:
                 # Push needed files
@@ -133,11 +133,12 @@ class Raw:
                     self.logger.debug(f"Finished operations on target {target}")
             
             except KeyboardInterrupt:
-                for future in futures:
-                    future.cancel()
-                    self.stop_event.set()
-                    for worker in self.workers:
-                        worker.cleanup()
+                self.stop_event.set()
+                self.logger.info(f"Shutting down threads...")
+                # Synchronize before cleaning-up to prevent race conditions
+                executor.shutdown(wait=True, cancel_futures=True)
+                for worker in self.workers:
+                    worker.cleanup()
 
         Exporter.export()
         return 0

--- a/staresc/core/raw.py
+++ b/staresc/core/raw.py
@@ -140,5 +140,4 @@ class Raw:
                 for worker in self.workers:
                     worker.cleanup()
 
-        Exporter.export()
         return 0

--- a/staresc/exporter/raw_handler.py
+++ b/staresc/exporter/raw_handler.py
@@ -20,8 +20,8 @@ class RawHandler(Handler):
             os.makedirs(output_dir, exist_ok=True)
 
             base_filename = f"{output.target.hostname}_{datetime.now().strftime('%m-%d_%H.%M.%S')}"
-            outstream = "\n\n".join(["$ " + r['stdin'] + "\n" + r['stdout'] for r in output.test_results])
-            errstream = "\n\n".join([r['stderr'] for r in output.test_results])
+            outstream = "\n\n".join(["$ " + r['stdin'] + "\n" + r['stdout'] for r in output.test_results]) + "\n"
+            errstream = "\n\n".join([r['stderr'] for r in output.test_results]) + "\n"
 
             with open(os.path.join(output_dir, base_filename + '.out.log'), 'a+') as f:
                 f.write(outstream)


### PR DESCRIPTION
After the refactoring of staresc the raw mode no longer works.

Here's a list of the fixed issues:
### Cli args
- The "timeout" cli arg has been set by default to "None" (instead of 2sec) in order to detect when the user manually sets the timeout vs when it hasn't been set at all. This allows to automatically assign a different timeout depending on the "mode", because 2 seconds are not enough for raw mode especially when running scripts such as linpeas etc.

### `Raw` class
- The `__init__()` method had list parameters initialized in the method's definition, so they were shared globally. This often causes bugs.
- `self.make_temp` was assigned based on the wrong condition: `len(self.commands) == 0 and not self.no_tmp`, it has been replaced with `len(self.commands) != 0 and not self.no_tmp`
- When catching a KeyboardInterrupt, the code would set the stop event and immediately proceed to perform the cleanup; this has been changed to wait for all the threads to stop in order to prevent race conditions between the cleanup code and code that was already running inside the workers.
- The `Exporter.export()` line at the end has been removed because it's already called inside `staresc.py` and it would produce doubled outputs

### `RawWorker` class
- In the `RawWorker` class, `timeout` was only ever passed to `prepare()`, whereas `exec()` had an hardcoded timeout of 3 seconds. A `timeout` field was added to the class and it is now passed in the constructor and used by both `prepare()` and `exec()`
- `RawWorker.tmp` has been changed to `RawWorker.cwd` for clarity (it's not always a temp folder, but it's always the current working directory)
- `RawWorker.__make_temp_dir()` raises an exception when sftp is uninitialized instead of exiting silently, as we don't want to accidentally delete the user's home folder by mistake when the `__delete_temp_dir()` is called
- For remote paths, `os.path.join()` has been replaced with `posixpath.join()`, because `os.path.join` uses the host separator and when run from Windows, it would construct the wrong paths by using the `\` separator instead of `/`
- The `disable` parameter of `tqdm.tqdm` has been set to `None`, as per tqdm docs when it is `None` it only shows the progress bar when we have a TTY (on the host, not the guest), but would not do it otherwise, which seems a safe choice to not mess up the terminal in weird situations
- the local and remote paths variables in `push()` and `pull()` have been renamed clarify which is which

### `SshConnection`
- in `run()` and `connect()` a check has been added to replace `timeout=0` with `timeout=None` because a 0 seconds timeout in Paramiko is taken literally: the connection is instantly killed

### `RawHandler`
- A newline char has been added at the end of the file to comply with POSIX standards.